### PR TITLE
replaces default labelPadding value in Axis with padding value in labelConfig

### DIFF
--- a/src/Axis.js
+++ b/src/Axis.js
@@ -59,6 +59,7 @@ export default class Axis extends BaseClass {
         fontFamily: new TextBox().fontFamily(),
         fontResize: false,
         fontSize: constant(10),
+        padding: 0,
         textAnchor: () => {
           const rtl = detectRTL();
           return this._orient === "left" ? rtl ? "start" : "end"
@@ -67,7 +68,6 @@ export default class Axis extends BaseClass {
         },
         verticalAlign: () => this._orient === "bottom" ? "top" : this._orient === "top" ? "bottom" : "middle"
       },
-      labelPadding: 0,
       r: d => d.tick ? 4 : 0,
       stroke: "#000",
       strokeWidth: 1,


### PR DESCRIPTION
(closes #47 )

<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
The reason why axis labels weren't rendering is because they were not getting a `padding` value of `0`. This is because in the [constructor for Axis](https://github.com/d3plus/d3plus-axis/blob/master/src/Axis.js#L70) we were setting the `labelPadding` value in `shapeConfig` instead of setting the `padding` value in `labelConfig`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

