### PR TITLE
adds label rotation method

### DIFF
--- a/src/Axis.js
+++ b/src/Axis.js
@@ -803,9 +803,9 @@ export default class Axis extends BaseClass {
       @desc If *value* is specified, sets whether offsets will be used to position some labels further away from the axis in order to allow space for the text.
       @param {Boolean} [*value* = true]
       @chainable
-  */
+   */
   labelOffset(_) {
-    return arguments.length ? (this._labelOffset = _, this) : this._labels;
+    return arguments.length ? (this._labelOffset = _, this) : this._labelOffset;
   }
 
   /**

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -393,7 +393,7 @@ export default class Axis extends BaseClass {
 
     const labelHeight = max(textData, t => t.height) || 0;
 
-    if (horizontal) {
+    if (horizontal && typeof this._labelRotation === "undefined") {
       for (let i = 0; i < labels.length; i++) {
         const d = labels[i];
 
@@ -427,6 +427,7 @@ export default class Axis extends BaseClass {
         }
       }
     }
+    else if (horizontal) this._rotateLabels = this._labelRotation;
 
     if (this._rotateLabels) {
       textData = labels.map((d, i) => {
@@ -806,6 +807,16 @@ export default class Axis extends BaseClass {
    */
   labelOffset(_) {
     return arguments.length ? (this._labelOffset = _, this) : this._labelOffset;
+  }
+
+  /**
+      @memberof Axis
+      @desc If *value* is specified, sets whether whether horizontal axis labels are rotated -90 degrees.
+      @param {Boolean}
+      @chainable
+   */
+  labelRotation(_) {
+    return arguments.length ? (this._labelRotation = _, this) : this._labelRotation;
   }
 
   /**

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -66,7 +66,7 @@ export default class Axis extends BaseClass {
           const rtl = detectRTL();
           return this._orient === "left" ? rtl ? "start" : "end"
             : this._orient === "right" ? rtl ? "end" : "start"
-            : this._rotateLabels ? "end" : "middle";
+            : this._rotateLabels ? this._orient === "bottom" ? "end" : "start" : "middle";
         },
         verticalAlign: () => this._orient === "bottom" ? "top" : this._orient === "top" ? "bottom" : "middle"
       },
@@ -648,7 +648,7 @@ export default class Axis extends BaseClass {
           tickConfig = Object.assign(tickConfig, {
             labelBounds: {
               x: -width / 2,
-              y: this._orient === "bottom" ? size + p + (width - lineHeight * numLines) / 2 : -size - p - (width + height) / 2,
+              y: this._orient === "bottom" ? size + p + (width - lineHeight * numLines) / 2 : size - p * 2 - (width + lineHeight * numLines) / 2,
               width,
               height: height + 1
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #53 )

### Description
<!--- Describe your changes in detail -->
- fixes mistake from previously implemented labelOffset method where calling `.labelOffset()` would return `this._labels`
- adds labelRotation method
- fixes bug with rotated label positioning when `orient` is `top` by setting the `textAnchor` to `start` when the `orient` is `top` and correcting `y-position` calculation

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

