### PR TITLE
removes month labels in timeScale

### DIFF
--- a/src/Axis.js
+++ b/src/Axis.js
@@ -165,7 +165,7 @@ export default class Axis extends BaseClass {
     if (this._d3Scale) {
       const positiveRange = this._d3Scale.range();
       const size = positiveRange[1] - positiveRange[0];
-      ticks = this._scale === "time" ? ticks.concat(this._d3Scale.ticks(timeYear)) : ticks.concat(this._d3Scale.ticks(Math.floor(size$1 / tickScale(size$1))));
+      ticks = this._scale === "time" ? ticks.concat(this._d3Scale.ticks(timeYear)) : ticks.concat(this._d3Scale.ticks(Math.floor(size / tickScale(size))));
     }
 
     return ticks;

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -295,7 +295,6 @@ export default class Axis extends BaseClass {
     labels = labels.slice();
 
     if (this._scale === "log") labels = labels.filter(t => Math.abs(t).toString().charAt(0) === "1" && (this._d3Scale ? t !== -1 : t !== 1));
-    if (this._scale === "time" && this._ticks) labels = ticks;
 
     const superscript = "⁰¹²³⁴⁵⁶⁷⁸⁹";
     const tickFormat = this._tickFormat ? this._tickFormat : d => {

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -6,6 +6,7 @@
 import {extent, max, min, range as d3Range} from "d3-array";
 import * as scales from "d3-scale";
 import {select} from "d3-selection";
+import {timeYear} from "d3-time";
 import {transition} from "d3-transition";
 
 import {assign, attrize, BaseClass, closest, constant, elem} from "d3plus-common";
@@ -164,7 +165,7 @@ export default class Axis extends BaseClass {
     if (this._d3Scale) {
       const positiveRange = this._d3Scale.range();
       const size = positiveRange[1] - positiveRange[0];
-      ticks = ticks.concat(this._d3Scale.ticks(Math.floor(size / tickScale(size))));
+      ticks = this._scale === "time" ? ticks.concat(this._d3Scale.ticks(timeYear)) : ticks.concat(this._d3Scale.ticks(Math.floor(size$1 / tickScale(size$1))));
     }
 
     return ticks;

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -295,6 +295,7 @@ export default class Axis extends BaseClass {
     labels = labels.slice();
 
     if (this._scale === "log") labels = labels.filter(t => Math.abs(t).toString().charAt(0) === "1" && (this._d3Scale ? t !== -1 : t !== 1));
+    if (this._scale === "time" && this._ticks) labels = ticks;
 
     const superscript = "⁰¹²³⁴⁵⁶⁷⁸⁹";
     const tickFormat = this._tickFormat ? this._tickFormat : d => {


### PR DESCRIPTION
(closes #64)

### Description
This bug was caused because timeScale it was using default behavior in `d3Scale`. I solved it adding `timeYear` from `d3-time` that returns data from year.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

