### PR TITLE
adds formatAbbreviate to axis

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "d3-selection": "^1.3.2",
     "d3-transition": "^1.1.3",
     "d3plus-common": "^0.6.43",
+    "d3plus-format": "^0.1.1",
     "d3plus-shape": "^0.16.0",
     "d3plus-text": "^0.9.33"
   },

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -307,7 +307,7 @@ export default class Axis extends BaseClass {
         return d < 0 ? `-${n}` : n;
       }
 
-      const n = this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
+      const n = this._tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
       return isNaN(parseFloat(n, 10)) ? n : formatAbbreviate(n);
     };
 

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -308,8 +308,8 @@ export default class Axis extends BaseClass {
       }
 
       let n = this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
-      n = n.replace(/[^\d\.\-eE+]/g, "") * 1;
-      return isNaN(parseFloat(n, 10)) ? n : formatAbbreviate(n);
+      n = n.replace(/[^\d\.\-\+]/g, "") * 1;
+      return isNaN(n) ? n : formatAbbreviate(n);
     };
 
     if (this._scale === "time") {

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -38,6 +38,7 @@ export default class Axis extends BaseClass {
     };
     this._domain = [0, 10];
     this._duration = 600;
+    this._format = false;
     this._gridConfig = {
       "stroke": "#ccc",
       "stroke-width": 1
@@ -306,7 +307,10 @@ export default class Axis extends BaseClass {
         if (t !== "1") n = `${t} x ${n}`;
         return d < 0 ? `-${n}` : n;
       }
-      return this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
+
+      if (!this._format) return this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
+      else return formatAbbreviate(d);
+
     };
 
     if (this._scale === "time") {

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -305,6 +305,9 @@ export default class Axis extends BaseClass {
         let n = `10 ${`${p}`.split("").map(c => superscript[c]).join("")}`;
         if (t !== "1") n = `${t} x ${n}`;
         return d < 0 ? `-${n}` : n;
+      } 
+      else if (this._scale === "time") {
+        return this._d3Scale.tickFormat(labels.length - 1)(d);
       }
 
       let n = this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -9,6 +9,7 @@ import {select} from "d3-selection";
 import {transition} from "d3-transition";
 
 import {assign, attrize, BaseClass, closest, constant, elem} from "d3plus-common";
+import {formatAbbreviate} from "d3plus-format";
 import * as shapes from "d3plus-shape";
 import {rtl as detectRTL, TextBox, textWidth, textWrap} from "d3plus-text";
 
@@ -748,6 +749,16 @@ export default class Axis extends BaseClass {
   */
   duration(_) {
     return arguments.length ? (this._duration = _, this) : this._duration;
+  }
+
+  /**
+      @memberof Axis
+      @desc If *value* is specified, sets the abbreviate format in ticks.
+      @param {Boolean} [*value* = false]
+      @chainable
+   */
+  format(_) {
+    return arguments.length ? (this._format = _, this) : this._format;
   }
 
   /**

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -38,7 +38,6 @@ export default class Axis extends BaseClass {
     };
     this._domain = [0, 10];
     this._duration = 600;
-    this._format = false;
     this._gridConfig = {
       "stroke": "#ccc",
       "stroke-width": 1
@@ -308,9 +307,8 @@ export default class Axis extends BaseClass {
         return d < 0 ? `-${n}` : n;
       }
 
-      if (!this._format) return this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
-      else return formatAbbreviate(d);
-
+      const n = this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
+      return isNaN(parseFloat(n, 10)) ? n : formatAbbreviate(n);
     };
 
     if (this._scale === "time") {
@@ -753,16 +751,6 @@ export default class Axis extends BaseClass {
   */
   duration(_) {
     return arguments.length ? (this._duration = _, this) : this._duration;
-  }
-
-  /**
-      @memberof Axis
-      @desc If *value* is specified, sets the abbreviate format in ticks.
-      @param {Boolean} [*value* = false]
-      @chainable
-   */
-  format(_) {
-    return arguments.length ? (this._format = _, this) : this._format;
   }
 
   /**

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -307,7 +307,8 @@ export default class Axis extends BaseClass {
         return d < 0 ? `-${n}` : n;
       }
 
-      const n = this._tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
+      let n = this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
+      n = n.replace(/[^\d\.\-eE+]/g, "") * 1;
       return isNaN(parseFloat(n, 10)) ? n : formatAbbreviate(n);
     };
 

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -309,8 +309,12 @@ export default class Axis extends BaseClass {
       else if (this._scale === "time") {
         return this._d3Scale.tickFormat(labels.length - 1)(d);
       }
+      else if (this._scale === "ordinal") {
+        return d;
+      }
 
       let n = this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
+
       n = n.replace(/[^\d\.\-\+]/g, "") * 1;
       return isNaN(n) ? n : formatAbbreviate(n);
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #61 

### Description
<!--- Describe your changes in detail -->
Adds format option in `d3plus-axis`, using `formatAbbreviate` function available in `d3plus-format`. If `.format(true)`, abbreviates every label of the axis.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

