### PR TITLE
fixes weird behavior using smallest tickSuffix

### DIFF
--- a/src/Axis.js
+++ b/src/Axis.js
@@ -92,7 +92,7 @@ export default class Axis extends BaseClass {
     this._tickSize = 5;
     this._tickSpecifier = undefined;
     this._tickSuffix = "normal";
-    this._tickUnit = 1;
+    this._tickUnit = 0;
     this._titleClass = new TextBox();
     this._titleConfig = {
       fontSize: 12,
@@ -387,9 +387,10 @@ export default class Axis extends BaseClass {
        */
       if (this._scale === "linear" && this._tickSuffix === "smallest") {
         let i = 1;
+        const min = Math.min(...ticks);
         while (i && i < 7) {
           const n = Math.pow(10, 3 * i);
-          if (ticks[ticks.length - 1] / n >= 1) {
+          if (min / n >= 1) {
             this._tickUnit = i;
             i += 1;
           }
@@ -460,7 +461,6 @@ export default class Axis extends BaseClass {
       }
 
       let n = this._d3Scale.tickFormat ? this._d3Scale.tickFormat(labels.length - 1)(d) : d;
-
       n = n.replace(/[^\d\.\-\+]/g, "") * 1;
 
       if (isNaN(n)) {

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -386,16 +386,19 @@ export default class Axis extends BaseClass {
        * Get the smallest suffix.
        */
       if (this._scale === "linear" && this._tickSuffix === "smallest") {
-        let i = 1;
-        const min = Math.min(...ticks);
-        while (i && i < 7) {
-          const n = Math.pow(10, 3 * i);
-          if (min / n >= 1) {
-            this._tickUnit = i;
-            i += 1;
-          }
-          else {
-            break;
+        const suffixes = labels.filter(d => d >= 1000);
+        if (suffixes.length > 0) {
+          const min = Math.min(...suffixes);
+          let i = 1;
+          while (i && i < 7) {
+            const n = Math.pow(10, 3 * i);
+            if (min / n >= 1) {
+              this._tickUnit = i;
+              i += 1;
+            }
+            else {
+              break;
+            }
           }
         }
       }
@@ -469,8 +472,8 @@ export default class Axis extends BaseClass {
       else if (this._scale === "linear" && this._tickSuffix === "smallest") {
         const locale = formatLocale[this._locale];
         const {separator, suffixes} = locale;
-        const suff = suffixes[this._tickUnit + 8];
-        return `${n / Math.pow(10, 3 * this._tickUnit)}${separator}${suff}`;
+        const suff = n >= 1000 ? suffixes[this._tickUnit + 8] : "";
+        return `${this._d3Scale.tickFormat()(n / Math.pow(10, 3 * this._tickUnit))}${separator}${suff}`;
       }
       else {
         return formatAbbreviate(n, this._locale);

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -473,7 +473,8 @@ export default class Axis extends BaseClass {
         const locale = formatLocale[this._locale];
         const {separator, suffixes} = locale;
         const suff = n >= 1000 ? suffixes[this._tickUnit + 8] : "";
-        return `${this._d3Scale.tickFormat()(n / Math.pow(10, 3 * this._tickUnit))}${separator}${suff}`;
+        const number = n > 1 ? this._d3Scale.tickFormat()(n / Math.pow(10, 3 * this._tickUnit)) : n;
+        return `${number}${separator}${suff}`;
       }
       else {
         return formatAbbreviate(n, this._locale);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #85 

This bug was caused because `this._tickUnit` was inicializated in `1`, and evaluating `Math.pow(10, 1)`, the first unit returned always was `k`. Also, I changed the behavior to get the minimum tick, because in edge case, users could want to sort the axis from max to min numbers.

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

