### PR TITLE
includes support to custom locale format using tickSuffix: "smallest"

### DIFF
--- a/src/Axis.js
+++ b/src/Axis.js
@@ -470,7 +470,7 @@ export default class Axis extends BaseClass {
         return n;
       }
       else if (this._scale === "linear" && this._tickSuffix === "smallest") {
-        const locale = formatLocale[this._locale];
+        const locale = typeof this._locale === "object" ? this._locale : formatLocale[this._locale];
         const {separator, suffixes} = locale;
         const suff = n >= 1000 ? suffixes[this._tickUnit + 8] : "";
         const number = n > 1 ? this._d3Scale.tickFormat()(n / Math.pow(10, 3 * this._tickUnit)) : n;

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -914,7 +914,7 @@ export default class Axis extends BaseClass {
   /**
       @memberof Viz
       @desc If *value* is specified, sets the locale to the specified string and returns the current class instance.
-      @param {String} [*value* = "en-US"]
+      @param {Object|String} [*value* = "en-US"]
       @chainable
   */
   locale(_) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Currently, using `tickSuffix: "smallest"`, only we can use the `locale` formatters defined previously in `d3plus-format`. With this small feature, you can pass a object in the `.locale` to define a custom formatter.

I'm testing with this code:

```
var bottom = new d3plus.AxisBottom()
    //.domain([0, 100])
    .domain([1000, 1000000])
  .tickSuffix("smallest")
  .locale({
    separator: " ",
    suffixes: ["y", "z", "a", "f", "p", "n", "µ", "m", "", "tuhat eurot", "miljonit eurot", "miljardit eurot", "triljonit eurot", "q eurot", "Q", "Z", "Y"],
    grouping: [3],
    delimiters: {
      thousands: " ",
      decimal: ","
    },
    currency: ["", "eurot"]
  })
  .width(600)
  .height(300)
  .render();
```

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

