### PR TITLE
enables locale format for tickSuffix smallest

### DIFF
--- a/src/Axis.js
+++ b/src/Axis.js
@@ -472,9 +472,10 @@ export default class Axis extends BaseClass {
       else if (this._scale === "linear" && this._tickSuffix === "smallest") {
         const locale = typeof this._locale === "object" ? this._locale : formatLocale[this._locale];
         const {separator, suffixes} = locale;
+        const thousands = locale.delimiters && locale.delimiters.thousands ? locale.delimiters.thousands : ",";
         const suff = n >= 1000 ? suffixes[this._tickUnit + 8] : "";
         const number = n > 1 ? this._d3Scale.tickFormat()(n / Math.pow(10, 3 * this._tickUnit)) : n;
-        return `${number}${separator}${suff}`;
+        return `${number.toString().replace(",", thousands)}${separator}${suff}`;
       }
       else {
         return formatAbbreviate(n, this._locale);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
In this moment, the locale format was not working when we set `tickSuffix("smallest")`. Now, this PR solves that bug.

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

