### PR TITLE
passes down locale method in favor of BaseClass

### DIFF
--- a/src/Axis.js
+++ b/src/Axis.js
@@ -56,7 +56,6 @@ export default class Axis extends BaseClass {
     this._gridLog = false;
     this._height = 400;
     this._labelOffset = true;
-    this._locale = "en-US";
     this.orient("bottom");
     this._outerBounds = {width: 0, height: 0, x: 0, y: 0};
     this._padding = 5;
@@ -909,16 +908,6 @@ export default class Axis extends BaseClass {
    */
   labelRotation(_) {
     return arguments.length ? (this._labelRotation = _, this) : this._labelRotation;
-  }
-
-  /**
-      @memberof Viz
-      @desc If *value* is specified, sets the locale to the specified string and returns the current class instance.
-      @param {Object|String} [*value* = "en-US"]
-      @chainable
-  */
-  locale(_) {
-    return arguments.length ? (this._locale = _, this) : this._locale;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
related with:
d3plus/d3plus-common#86
d3plus/d3plus-viz#75

This PR passes down locale method in favor of BaseClass

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

