### PR TITLE
improves logic formatting numbers using smallest suffix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d3plus-axis",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1170,9 +1170,9 @@
       }
     },
     "d3plus-format": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-0.1.9.tgz",
-      "integrity": "sha512-BOJHursLgoeNrVt/4TaVTxTcu5CLDNsq664sDY/ojrbk4+R8zsZRnAfRE8iGTmeaLMuOkWAnTWf10Cw2Q8H+vA==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/d3plus-format/-/d3plus-format-0.1.11.tgz",
+      "integrity": "sha512-Up3MZ22coRqffDEZ3dfr9DLNdDc/uEziZXRDfphyPAuFigiMhuParNxq9Sc4cAn6FlcIhs1BLUsZ3KvdNXT9Rw==",
       "requires": {
         "d3-format": "^1.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "d3-selection": "^1.3.2",
     "d3-transition": "^1.1.3",
     "d3plus-common": "^0.6.48",
-    "d3plus-format": "^0.1.9",
+    "d3plus-format": "^0.1.11",
     "d3plus-shape": "^0.16.8",
     "d3plus-text": "^0.9.43"
   },

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -473,7 +473,8 @@ export default class Axis extends BaseClass {
         const locale = typeof this._locale === "object" ? this._locale : formatLocale[this._locale];
         const {separator, suffixes} = locale;
         const suff = n >= 1000 ? suffixes[this._tickUnit + 8] : "";
-        const number = formatAbbreviate(n / Math.pow(10, 3 * this._tickUnit), locale, false);
+        const tick = n / Math.pow(10, 3 * this._tickUnit);
+        const number = formatAbbreviate(tick, locale, `,.${tick.toString().length}r`);
         return `${number}${separator}${suff}`;
       }
       else {

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -4,7 +4,6 @@
 */
 
 import {extent, max, min, range as d3Range, ticks as d3Ticks} from "d3-array";
-import {formatLocale as formatLocaleD3} from "d3-format";
 import {timeYear, timeMonth, timeWeek, timeDay, timeHour, timeMinute, timeSecond} from "d3-time";
 import {timeFormat} from "d3-time-format";
 import * as scales from "d3-scale";
@@ -472,17 +471,9 @@ export default class Axis extends BaseClass {
       }
       else if (this._scale === "linear" && this._tickSuffix === "smallest") {
         const locale = typeof this._locale === "object" ? this._locale : formatLocale[this._locale];
-        const {currency, delimiters, grouping, separator, suffixes} = locale;
-        const d3plusFormatLocale = formatLocaleD3({
-          currency: currency || ["$", ""],
-          decimal: delimiters.decimal || ".",
-          grouping: grouping || [3],
-          thousands: delimiters.thousands || ","
-        });
+        const {separator, suffixes} = locale;
         const suff = n >= 1000 ? suffixes[this._tickUnit + 8] : "";
-        let number = n > 1 ? n / Math.pow(10, 3 * this._tickUnit) : n;
-        const len = number.toString().length;
-        if (n > 1) number = d3plusFormatLocale.format(`,.${len}r`)(number);
+        const number = formatAbbreviate(n / Math.pow(10, 3 * this._tickUnit), locale, false);
         return `${number}${separator}${suff}`;
       }
       else {

--- a/src/Axis.js
+++ b/src/Axis.js
@@ -4,6 +4,7 @@
 */
 
 import {extent, max, min, range as d3Range, ticks as d3Ticks} from "d3-array";
+import {formatLocale as formatLocaleD3} from "d3-format";
 import {timeYear, timeMonth, timeWeek, timeDay, timeHour, timeMinute, timeSecond} from "d3-time";
 import {timeFormat} from "d3-time-format";
 import * as scales from "d3-scale";
@@ -471,9 +472,17 @@ export default class Axis extends BaseClass {
       }
       else if (this._scale === "linear" && this._tickSuffix === "smallest") {
         const locale = typeof this._locale === "object" ? this._locale : formatLocale[this._locale];
-        const {separator, suffixes} = locale;
+        const {currency, delimiters, grouping, separator, suffixes} = locale;
+        const d3plusFormatLocale = formatLocaleD3({
+          currency: currency || ["$", ""],
+          decimal: delimiters.decimal || ".",
+          grouping: grouping || [3],
+          thousands: delimiters.thousands || ","
+        });
         const suff = n >= 1000 ? suffixes[this._tickUnit + 8] : "";
-        const number = n > 1 ? this._d3Scale.tickFormat()(n / Math.pow(10, 3 * this._tickUnit)) : n;
+        let number = n > 1 ? n / Math.pow(10, 3 * this._tickUnit) : n;
+        const len = number.toString().length;
+        if (n > 1) number = d3plusFormatLocale.format(`,.${len}r`)(number);
         return `${number}${separator}${suff}`;
       }
       else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
related with d3plus/d3plus-format#7

@davelandry I considered your feedback, and now `tickSuffix("smallest")` uses `formatAbbreviate`. :)

### Description
<!--- Describe your changes in detail -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

